### PR TITLE
Hotfixes/v2.0.6 fix gens name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-### v2.0.7
-- Fixed the change of the default reference genome from hg38 with unmasked to hg38 with masked regions for the CNV calling. The CNV calling will now use the hg38 with masked regions as default reference genome.
-- Fixed the issue with name suffix for the wgs sample in the GENS load command. The suffix will now be added to the sample name in the GENS load command.
+## v2.0.7
+ - Changed the default reference genome for CNV calling from unmasked hg38 to hg38 with masked regions. CNV calling now uses the masked hg38 reference by default.
+ - Fixed the missing "-wgs" suffix in the GENS load command by appending it to the case/group id ("--case-id"), when needed.
 
 ## v2.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### v2.0.7
+- Fixed the change of the default reference genome from hg38 with unmasked to hg38 with masked regions for the CNV calling. The CNV calling will now use the hg38 with masked regions as default reference genome.
+- Fixed the issue with name suffix for the wgs sample in the GENS load command. The suffix will now be added to the sample name in the GENS load command.
+
 ## v2.0.6
 
 - Fixes automatically different illuminia platforms based on the csv information

--- a/modules/sentieon/main.nf
+++ b/modules/sentieon/main.nf
@@ -1358,7 +1358,7 @@ process COYOTE {
         path (cnvplot)
 
     output:
-        path ("*.coyote_wgs")   // use the modified name
+        path ("*.coyote_wgs")   
 
     script:
     // Define a new group identifier with "-wgs" if missing

--- a/modules/sentieon/main.nf
+++ b/modules/sentieon/main.nf
@@ -1358,7 +1358,7 @@ process COYOTE {
         path (cnvplot)
 
     output:
-        path ("${group_id}.coyote_wgs")   // use the modified name
+        path ("*.coyote_wgs")   // use the modified name
 
     script:
     // Define a new group identifier with "-wgs" if missing

--- a/modules/sentieon/main.nf
+++ b/modules/sentieon/main.nf
@@ -1291,18 +1291,20 @@ process GENERATE_GENS_DATA {
 	input:
 		path(params.GENS_GNOMAD)
 		tuple	val(id), path(gvcf), path(cov_stand), path(cov_denoise)
-		tuple	val(g), val(sampleID), val(type), val(lims_id), val(pool_id), val (assay)
+		tuple	val(group), val(sampleID), val(type), val(lims_id), val(pool_id), val (assay)
 
 	output:
 		tuple	path("${id}.cov.bed.gz"), path("${id}.baf.bed.gz"), path("${id}.cov.bed.gz.tbi"), path("${id}.baf.bed.gz.tbi"), path ("${id}.overview.json.gz")
 		path	("${id}_${assay}.gens")
 
 	script:
+	
+	def group_id = group.contains("-wgs") ? group : group + "-wgs"
 
 	"""
 	generate_gens_data.pl ${cov_stand} ${gvcf} ${id} ${params.GENS_GNOMAD}
 
-	echo "gens load sample --sample-id ${id} --case-id ${g} --genome-build 38 --baf ${params.gens_accessdir}/${id}.baf.bed.gz --coverage ${params.gens_accessdir}/${id}.cov.bed.gz --overview-json ${params.gens_accessdir}/${id}.overview.json.gz" > ${id}_${assay}.gens 
+	echo "gens load sample --sample-id ${id} --case-id ${group_id} --genome-build 38 --baf ${params.gens_accessdir}/${id}.baf.bed.gz --coverage ${params.gens_accessdir}/${id}.cov.bed.gz --overview-json ${params.gens_accessdir}/${id}.overview.json.gz" > ${id}_${assay}.gens 
 	"""
 }
 
@@ -1325,7 +1327,7 @@ process GENERATE_GENS_DATA_NOR {
 	input:
 		path(params.GENS_GNOMAD)
 		tuple	val(id), path(gvcf), path(cov_stand), path(cov_denoise) 
-		tuple	val(g), val(sampleID), val(type), val(lims_id), val(pool_id), val (assay)
+		tuple	val(group), val(sampleID), val(type), val(lims_id), val(pool_id), val (assay)
 
 	output:
 		tuple	path("${id}.cov.bed.gz"), path("${id}.baf.bed.gz"), path("${id}.cov.bed.gz.tbi"), path("${id}.baf.bed.gz.tbi"), path("${id}.overview.json.gz")
@@ -1334,68 +1336,66 @@ process GENERATE_GENS_DATA_NOR {
 	
 	script:
 
+	def group_id = group.contains("-wgs") ? group : group + "-wgs"
+	
 	"""
 	generate_gens_data.pl ${cov_stand} ${gvcf} ${id} ${params.GENS_GNOMAD}
 	
-	echo "gens load sample --sample-id ${id} --case-id ${g} --genome-build 38 --baf ${params.gens_accessdir}/${id}.baf.bed.gz --coverage ${params.gens_accessdir}/${id}.cov.bed.gz --overview-json ${params.gens_accessdir}/${id}.overview.json.gz" > ${id}_${assay}.gens 
+	echo "gens load sample --sample-id ${id} --case-id ${group_id} --genome-build 38 --baf ${params.gens_accessdir}/${id}.baf.bed.gz --coverage ${params.gens_accessdir}/${id}.cov.bed.gz --overview-json ${params.gens_accessdir}/${id}.overview.json.gz" > ${id}_${assay}.gens 
 	"""
 }
 
-
 process COYOTE {
-	tag "$group"
-	label "process_low"	
-	publishDir "${params.crondir}/coyote", 
-				mode: 'copy', 
-				overwrite: true
+    tag "$group"
+    label "process_low"  
+    publishDir "${params.crondir}/coyote", 
+                mode: 'copy', 
+                overwrite: true
 
-	input:
-		tuple 	val(group), path(vcf), path(cnv), path(fusions)
-		tuple	val(g), val(sampleID), val(type), val(lims_id), val(pool_id), val (assay)
-		path (cnvplot)
+    input:
+        tuple  val(group), path(vcf), path(cnv), path(fusions)
+        tuple  val(g), val(sampleID), val(type), val(lims_id), val(pool_id), val(assay)
+        path (cnvplot)
 
-	output:
-		path ("${group}.coyote_wgs")
+    output:
+        path ("${group_id}.coyote_wgs")   // use the modified name
 
-	script:
-	if( lims_id.size() >= 2 ) {
-		tumor_idx = type.findIndexOf{ it == 'tumor' || it == 'T' }
-		normal_idx = type.findIndexOf{ it == 'normal' || it == 'N' }
+    script:
+    // Define a new group identifier with "-wgs" if missing
+    def group_id = group.contains("-wgs") ? group : group + "-wgs"
 
-		// def gens_tumor = ${sampleID[tumor_idx]} + ${assay}
-		// def gens_normal = ${sampleID[normal_idx]} + ${assay}
+    if( lims_id.size() >= 2 ) {
+        tumor_idx = type.findIndexOf{ it == 'tumor' || it == 'T' }
+        normal_idx = type.findIndexOf{ it == 'normal' || it == 'N' }
 
-		"""
-			echo "/data/bnf/scripts/import_myeloid_to_coyote_vep_gms_dev_WGS.pl \\
-			--id ${group} --group tumwgs \\
-			--vcf /access/tumwgs/vcf/${vcf} \\
-			--cnv /access/tumwgs/cnv/${cnv} \\
-			--transloc /access/tumwgs/vcf/${fusions} \\
-			--cnvprofile /access/tumwgs/cov/${cnvplot} \\
-			--clarity-sample-id ${lims_id[tumor_idx]} \\
-			--build 38 \\
-        	--gens ${sampleID[tumor_idx]} \\
-			--gensNorm ${sampleID[normal_idx]} \\
-			--clarity-pool-id ${pool_id[tumor_idx]}" > ${group}.coyote_wgs
-		"""
-	}
-	else {
-		tumor_idx = type.findIndexOf{ it == 'tumor' || it == 'T' }
+        """
+        echo "/data/bnf/scripts/import_myeloid_to_coyote_vep_gms_dev_WGS.pl \\
+        --id ${group_id} --group tumwgs \\
+        --vcf /access/tumwgs/vcf/${vcf} \\
+        --cnv /access/tumwgs/cnv/${cnv} \\
+        --transloc /access/tumwgs/vcf/${fusions} \\
+        --cnvprofile /access/tumwgs/cov/${cnvplot} \\
+        --clarity-sample-id ${lims_id[tumor_idx]} \\
+        --build 38 \\
+        --gens ${sampleID[tumor_idx]} \\
+        --gensNorm ${sampleID[normal_idx]} \\
+        --clarity-pool-id ${pool_id[tumor_idx]}" > ${group_id}.coyote_wgs
+        """
+    }
+    else {
+        tumor_idx = type.findIndexOf{ it == 'tumor' || it == 'T' }
 
-		// def gens_tumor = ${sampleID[tumor_idx]} + ${assay}
-		
-		"""
-			echo "/data/bnf/scripts/import_myeloid_to_coyote_vep_gms_dev_WGS.pl \\
-			--id ${group} --group tumwgs \\
-			--vcf /access/tumwgs/vcf/${vcf} \\
-			--cnv /access/tumwgs/cnv/${cnv} \\
-			--transloc /access/tumwgs/vcf/${fusions} \\
-			--cnvprofile /access/tumwgs/cov/${cnvplot} \\
-			--clarity-sample-id ${lims_id[tumor_idx]} \\
-			--build 38 \\
-        	--gens ${sampleID[tumor_idx]} \\
-			--clarity-pool-id ${pool_id[tumor_idx]}" > ${group}.coyote_wgs
-
-		"""
-	}
+        """
+        echo "/data/bnf/scripts/import_myeloid_to_coyote_vep_gms_dev_WGS.pl \\
+        --id ${group_id} --group tumwgs \\
+        --vcf /access/tumwgs/vcf/${vcf} \\
+        --cnv /access/tumwgs/cnv/${cnv} \\
+        --transloc /access/tumwgs/vcf/${fusions} \\
+        --cnvprofile /access/tumwgs/cov/${cnvplot} \\
+        --clarity-sample-id ${lims_id[tumor_idx]} \\
+        --build 38 \\
+        --gens ${sampleID[tumor_idx]} \\
+        --clarity-pool-id ${pool_id[tumor_idx]}" > ${group_id}.coyote_wgs
+        """
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,7 +63,10 @@ profiles {
             // FASTA //
             //genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
             genome_file = "${refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.fna"
-            GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
+
+            // GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
+            GENOMEDICT="${params.refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.dict"
+          
         
             // VEP REFERENCES AND ANNOTATION DBS //
             CADD = "${refpath}/annotation_dbs/whole_genome_SNVs.tsv.gz"
@@ -180,7 +183,8 @@ profiles {
             // FASTA //
             //genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
             genome_file = "${refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.fna"
-            GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
+            // GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
+            GENOMEDICT = "${refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.dict"
     
             // VEP REFERENCES AND ANNOTATION DBS //
             CADD = "${refpath}/annotation_dbs/whole_genome_SNVs.tsv.gz"

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,7 +61,8 @@ profiles {
             intersect_bed = "${refpath}/bed/wgsexome/hg38_ens98_allcodingexons20bppadding_allclinvar5bppadding_agilent.noalt.bed"
 
             // FASTA //
-            genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
+            //genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
+            genome_file = "${refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.fna"
             GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
         
             // VEP REFERENCES AND ANNOTATION DBS //
@@ -177,9 +178,10 @@ profiles {
             intersect_bed = "${refpath}/bed/wgsexome/hg38_ens98_allcodingexons20bppadding_allclinvar5bppadding_agilent.noalt.bed"
 
             // FASTA //
-            genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
+            //genome_file = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.fna"
+            genome_file = "${refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.fna"
             GENOMEDICT = "${refpath}/fasta/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr.dict"
-        
+    
             // VEP REFERENCES AND ANNOTATION DBS //
             CADD = "${refpath}/annotation_dbs/whole_genome_SNVs.tsv.gz"
             VEP_FASTA = "${refpath}/vep/.vep/homo_sapiens_merged/98_GRCh38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz"


### PR DESCRIPTION
Hotfixes for the unwanted deletion and insertion called by gatk cnv calling due to use of masked genome while creating the PONs. The change was altering the unmasked genome build to the masked genome build so that the sample reference can be compared with the actual builds